### PR TITLE
added open with codeanywhere badge to README file

### DIFF
--- a/templates/container-with-vitest/README.md
+++ b/templates/container-with-vitest/README.md
@@ -7,5 +7,7 @@ npm create astro@latest -- --template container-with-vitest
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-vitest)
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/with-vitest)
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/with-vitest/devcontainer.json)
+[![Open in Codeanywhere](https://codeanywhere.com/img/open-in-codeanywhere-btn.svg)](https://app.codeanywhere.com/#https://github.com/withastro/astro/tree/latest/examples/with-vitest)
+
 
 This example showcases Astro working with [Vitest](https://vitest.dev/) and how to test components using the Container API.

--- a/templates/framework-preact/README.md
+++ b/templates/framework-preact/README.md
@@ -7,6 +7,7 @@ npm create astro@latest -- --template framework-preact
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/framework-preact)
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/framework-preact)
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/framework-preact/devcontainer.json)
+[![Open in Codeanywhere](https://codeanywhere.com/img/open-in-codeanywhere-btn.svg)](https://app.codeanywhere.com/#https://github.com/withastro/astro/tree/latest/examples/framework-preact)
 
 This example showcases Astro working with [Preact](https://preactjs.com).
 

--- a/templates/with-nanostores/README.md
+++ b/templates/with-nanostores/README.md
@@ -7,5 +7,6 @@ npm create astro@latest -- --template with-nanostores
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/with-nanostores)
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/with-nanostores)
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/with-nanostores/devcontainer.json)
+[![Open in Codeanywhere](https://codeanywhere.com/img/open-in-codeanywhere-btn.svg)](https://app.codeanywhere.com/#https://github.com/withastro/astro/tree/latest/examples/with-nanostores)
 
 This example showcases using [`nanostores`](https://github.com/nanostores/nanostores) to provide shared state between components of any framework. [**Read our documentation on sharing state**](https://docs.astro.build/en/core-concepts/sharing-state/) for a complete breakdown of this project, along with guides to use React, Vue, Svelte, or Solid!


### PR DESCRIPTION
Hey hey,

I’ve added a shiny new 'Open with Codeanywhere' badge to our README.md! 🚀

This badge makes it super easy for anyone to spin up a pre-configured dev environment—whether in the cloud or locally. It’s all set up to ensure everyone has access to the same tools, no fuss, no setup headaches. Perfect for contributors or anyone jumping into the codebase for the first time.

Let me know what you think or if there’s anything we can tweak!